### PR TITLE
Concurrent calls to one DocumentConverter race on shared parser state

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <NoWarn>NU1608</NoWarn>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>

--- a/src/Morph.OpenXml/DocumentConverter.cs
+++ b/src/Morph.OpenXml/DocumentConverter.cs
@@ -5,7 +5,6 @@ namespace WordRender;
 /// </summary>
 public abstract class DocumentConverter
 {
-    DocumentParser parser = new();
 
     /// <summary>
     /// Converts a DOCX file to PNG images.
@@ -32,7 +31,7 @@ public abstract class DocumentConverter
         options ??= new();
         Directory.CreateDirectory(outputDirectory);
 
-        var document = parser.Parse(docxStream);
+        var document = new DocumentParser().Parse(docxStream);
         var imagePaths = new List<string>();
 
         var pageIndex = 0;
@@ -72,7 +71,7 @@ public abstract class DocumentConverter
     {
         options ??= new();
 
-        var document = parser.Parse(docxStream);
+        var document = new DocumentParser().Parse(docxStream);
         var imageData = new List<byte[]>();
 
         RenderPages(document, options, writePng =>

--- a/src/Tests/DocumentConverterConcurrencyTests.cs
+++ b/src/Tests/DocumentConverterConcurrencyTests.cs
@@ -1,0 +1,71 @@
+#if !DEBUG
+
+public class DocumentConverterConcurrencyTests
+{
+    // A single DocumentConverter instance must produce byte-identical output for the same
+    // input across concurrent calls. Any mutable state hanging off the converter would get
+    // clobbered when callers hit it from multiple threads, so this test pins that contract.
+    //
+    // It interleaves two distinct inputs through the same converter so the parser sees
+    // overlapping work on different documents — that's what triggers the cross-contamination
+    // (parsing the same docx twice can mask the race because the overwritten field happens
+    // to hold the same value either way). complex_tables and bullet_list together exercise
+    // the parser fields the original race corrupted (style borders, numbering, theme).
+    //
+    // Both Skia and ImageSharp derive from WordRender.DocumentConverter, so the parse path
+    // covered here is shared across both backends.
+    [Test]
+    public async Task SharedConverterIsByteIdenticalUnderConcurrentRenders()
+    {
+        var inputsDir = Path.Combine(ProjectFiles.ProjectDirectory, "Inputs");
+        var inputA = await File.ReadAllBytesAsync(Path.Combine(inputsDir, "complex_tables", "input.docx"));
+        var inputB = await File.ReadAllBytesAsync(Path.Combine(inputsDir, "bullet_list", "input.docx"));
+
+        var converter = new WordRender.Skia.DocumentConverter();
+        var baselineA = Render(converter, inputA);
+        var baselineB = Render(converter, inputB);
+
+        var failures = new ConcurrentBag<string>();
+
+        await Parallel.ForAsync(0, 128, (i, _) =>
+        {
+            var useA = (i & 1) == 0;
+            var input = useA ? inputA : inputB;
+            var baseline = useA ? baselineA : baselineB;
+            var label = useA ? "complex_tables" : "bullet_list";
+
+            var pages = Render(converter, input);
+            if (pages.Count != baseline.Count)
+            {
+                failures.Add($"{label} iteration {i}: page count {pages.Count} != baseline {baseline.Count}");
+                return ValueTask.CompletedTask;
+            }
+
+            for (var page = 0; page < baseline.Count; page++)
+            {
+                if (!pages[page].AsSpan().SequenceEqual(baseline[page]))
+                {
+                    failures.Add($"{label} iteration {i} page {page + 1}: bytes differ from sequential baseline");
+                    break;
+                }
+            }
+
+            return ValueTask.CompletedTask;
+        });
+
+        if (!failures.IsEmpty)
+        {
+            throw new(
+                $"Shared DocumentConverter produced inconsistent output across threads:{Environment.NewLine}" +
+                string.Join(Environment.NewLine, failures.Distinct().Take(8)));
+        }
+    }
+
+    static IReadOnlyList<byte[]> Render(WordRender.DocumentConverter converter, byte[] docx)
+    {
+        using var stream = new MemoryStream(docx);
+        return converter.ConvertToImageData(stream);
+    }
+}
+
+#endif


### PR DESCRIPTION
  DocumentConverter held a single DocumentParser instance field, but DocumentParser carries mutable fields it overwrites during Parse (theme colors, numbering tables, table style borders, default spacing). Two threads calling ConvertToImageData on the same converter would clobber
  each other's parse state, producing inconsistent output for the same input.

  Allocate a fresh DocumentParser per Parse call. Add a release-only regression test that interleaves two distinct inputs through one shared converter and asserts byte-identical output against a sequential baseline.