### PR TITLE
Count table paragraphs when resolving a bookmark's page

### DIFF
--- a/src/Morph/OpenXml/DocumentConverter.cs
+++ b/src/Morph/OpenXml/DocumentConverter.cs
@@ -107,9 +107,12 @@ public abstract class DocumentConverter
         DefaultFontSettings.MarkRenderOccurred();
         var paragraphPages = ParagraphPages(document, options);
 
-        // A bookmark knows the ordinal of the body paragraph it sits in; layout knows where that
-        // paragraph landed. Joining the two is the whole trick.
-        var bodyParagraphs = document.Elements.OfType<ParagraphElement>().ToList();
+        // A bookmark knows the ordinal of the paragraph it sits in; layout knows where that
+        // paragraph landed. Joining the two is the whole trick — and the two sides have to count
+        // the same paragraphs, which means every w:p in document order rather than only the ones at
+        // body level. A table's cells hold paragraphs too, so counting only the top level shifts
+        // every bookmark below a table onto some other paragraph's page.
+        var bodyParagraphs = Flatten(document.Elements).ToList();
         foreach (var bookmark in document.Bookmarks)
         {
             if (bookmark.ParagraphIndex is not { } index ||
@@ -124,6 +127,49 @@ public abstract class DocumentConverter
         }
 
         return pages;
+    }
+
+    // Every paragraph under these elements, depth-first, matching the document order the parser
+    // assigns bookmark ordinals in (see DocumentParser's paragraph-ordinal map, which walks
+    // body.Descendants&lt;Paragraph&gt;()).
+    static IEnumerable<ParagraphElement> Flatten(IEnumerable<DocumentElement> elements)
+    {
+        foreach (var element in elements)
+        {
+            switch (element)
+            {
+                case ParagraphElement paragraph:
+                    yield return paragraph;
+                    break;
+                case TableElement table:
+                    foreach (var row in table.Rows)
+                    {
+                        foreach (var cell in row.Cells)
+                        {
+                            foreach (var nested in Flatten(cell.Content))
+                            {
+                                yield return nested;
+                            }
+                        }
+                    }
+
+                    break;
+                case FloatingTextBoxElement textBox:
+                    foreach (var nested in Flatten(textBox.Content))
+                    {
+                        yield return nested;
+                    }
+
+                    break;
+                case PositionedFrameElement frame:
+                    foreach (var nested in Flatten(frame.Content))
+                    {
+                        yield return nested;
+                    }
+
+                    break;
+            }
+        }
     }
 
     // The page each paragraph starts on, read straight off the laid-out tree: a placed line is

--- a/src/Tests/SpecTests/Export/BookmarkPageTests.cs
+++ b/src/Tests/SpecTests/Export/BookmarkPageTests.cs
@@ -39,6 +39,20 @@ public class BookmarkPageTests
         await Assert.That(pages["target"]).IsGreaterThan(1);
     }
 
+    // A table's cells are paragraphs too. Counting them on one side of the join and not the other
+    // silently shifts every bookmark below the table, which reads as a plausible page rather than a
+    // missing one — so a document with a table ahead of the anchor is the case worth pinning.
+    [Test]
+    public async Task ABookmarkAfterATableStillReportsItsOwnPage()
+    {
+        using var docx = BuildDocument(paragraphs: 3, bookmarkAt: 2, tableBeforeParagraph: 1);
+
+        var pages = DocumentConverter.GetBookmarkPages(docx, Options);
+
+        await Assert.That(pages.ContainsKey("target")).IsTrue();
+        await Assert.That(pages["target"]).IsEqualTo(1);
+    }
+
     [Test]
     public async Task ADocumentWithNoBookmarksReportsNothing()
     {
@@ -61,7 +75,7 @@ public class BookmarkPageTests
         await Assert.That(pages.ContainsKey("second")).IsTrue();
     }
 
-    static MemoryStream BuildDocument(int paragraphs, int? bookmarkAt, int? extraBookmarkAt = null)
+    static MemoryStream BuildDocument(int paragraphs, int? bookmarkAt, int? extraBookmarkAt = null, int? tableBeforeParagraph = null)
     {
         var stream = new MemoryStream();
         using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
@@ -70,6 +84,11 @@ public class BookmarkPageTests
             var body = new W.Body();
             for (var i = 0; i < paragraphs; i++)
             {
+                if (i == tableBeforeParagraph)
+                {
+                    body.Append(Table());
+                }
+
                 var paragraph = new W.Paragraph();
                 if (i == bookmarkAt)
                 {
@@ -92,6 +111,23 @@ public class BookmarkPageTests
         stream.Position = 0;
         return stream;
     }
+
+    // Two rows of two cells: four more w:p elements that are not body-level paragraphs.
+    static W.Table Table() =>
+        new(
+            new W.TableProperties(
+                new W.TableWidth
+                {
+                    Type = W.TableWidthUnitValues.Auto
+                }),
+            new W.TableGrid(new W.GridColumn(), new W.GridColumn()),
+            Row("a", "b"),
+            Row("c", "d"));
+
+    static W.TableRow Row(string left, string right) =>
+        new(
+            new W.TableCell(new W.Paragraph(new W.Run(new W.Text(left)))),
+            new W.TableCell(new W.Paragraph(new W.Run(new W.Text(right)))));
 
     static void Bookmark(W.Paragraph paragraph, string name, int id)
     {


### PR DESCRIPTION
A bookmark's ordinal counts every w:p in the document, tables included, but the join was walking only the elements at body level. Any document with a table ahead of an anchor therefore matched the bookmark against some other paragraph — reporting a page that looks plausible, or dropping the bookmark entirely once the ordinal ran past the end of the shorter list.

That is the failure this API is least able to afford: a page number nothing marks as suspect. Found by a report whose summary table sits above every section it references, so every cross-reference in it was wrong.

Both sides now walk the same paragraphs, depth-first through tables, text boxes and positioned frames.