### PR TITLE
Draw the Wingdings checkbox pair as ballot boxes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <NoWarn>NU1608;SC023</NoWarn>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>

--- a/src/Morph/EmbeddedFonts/Bullets.md
+++ b/src/Morph/EmbeddedFonts/Bullets.md
@@ -36,8 +36,8 @@ looks up `U+2022` etc. and gets a glyph whose visual weight matches Word.
 | U+2713 | `✓` | Checkmark (Wingdings) | Wingdings | 0xF0FC |
 | U+25B8 | `▸` | Small right triangle (drawn) | synthesized | — |
 | U+25BA | `►` | Right pointer (drawn) | synthesized | — |
-| U+2610 | `☐` | Legacy FORMCHECKBOX unchecked (drawn; box ≈1.15em dipping below baseline, matching Word's field rendering) | synthesized | — |
-| U+2612 | `☒` | Legacy FORMCHECKBOX checked (drawn) | synthesized | — |
+| U+2610 | `☐` | Legacy FORMCHECKBOX unchecked, and the Wingdings 0xA8 bullet a questionnaire template draws an empty checkbox with (drawn; box ≈1.15em dipping below baseline, matching Word's field rendering) | synthesized | — |
+| U+2612 | `☒` | Legacy FORMCHECKBOX checked, and the Wingdings 0xFE bullet that pairs with it (drawn) | synthesized | — |
 
 ## Licensing
 

--- a/src/Morph/OpenXml/Parsing/DocumentParser.cs
+++ b/src/Morph/OpenXml/Parsing/DocumentParser.cs
@@ -2923,8 +2923,12 @@ sealed class DocumentParser(string defaultFont)
                 '' => "▪",
                 // Wingdings 0xA7 - black small square (Word's default bullet at ilvl 2)
                 '' => "▪",
-                // Wingdings 0xA8 - white square
-                '' => "▢",
+                // Wingdings 0xA8 - white square, which is how a Word template draws an empty
+                // checkbox. U+2610 rather than U+25A2 white square: Bullets.ttf carries the
+                // ballot box and not the square, so the closer codepoint rendered as nothing.
+                '' => "☐",
+                // Wingdings 0xFE - ballot box with X, the checked half of that pair
+                '' => "☒",
                 // Wingdings 0xFC - check mark
                 '' => "✓",
                 // Wingdings 0xFB - ballot X

--- a/src/Tests/SpecTests/Section2_Structures/BulletCheckboxTests.cs
+++ b/src/Tests/SpecTests/Section2_Structures/BulletCheckboxTests.cs
@@ -1,0 +1,130 @@
+/// <summary>
+/// Covers the Wingdings checkbox pair in <c>DocumentParser.MapBulletPuaToUnicode</c>. A Word
+/// template that renders a questionnaire draws its boxes as list markers, so the pair has to survive
+/// the hop from Wingdings' private-use codepoints onto the Unicode ones <c>Bullets.ttf</c> carries —
+/// and <c>Bullets.ttf</c> is what actually draws the marker, whatever font the numbering names.
+/// </summary>
+public class BulletCheckboxTests
+{
+    // Wingdings 0xA8 and 0xFE, shifted into the F000 private-use block the way Word stores them.
+    const string emptyBox = "\uF0A8";
+    const string checkedBox = "\uF0FE";
+
+    [Test]
+    public async Task WingdingsCheckboxesBecomeBallotBoxes()
+    {
+        var markers = Markers(("Wingdings", emptyBox), ("Wingdings", checkedBox));
+
+        await Assert.That(markers[0]).IsEqualTo("☐");
+        await Assert.That(markers[1]).IsEqualTo("☒");
+    }
+
+    // The same codepoint means something else in Symbol, which is why the lookup branches on the
+    // font before the character. 0xA8 is a hollow circle there, not a box.
+    [Test]
+    public async Task TheSameCodepointInSymbolStaysACircle()
+    {
+        var markers = Markers(("Symbol", emptyBox));
+
+        await Assert.That(markers[0]).IsEqualTo("○");
+    }
+
+    static List<string> Markers(params (string Font, string LevelText)[] levels)
+    {
+        var parser = new DocumentParser();
+        using var stream = new MemoryStream(BuildDocx(levels));
+        return parser.Parse(stream)
+            .Elements
+            .OfType<ParagraphElement>()
+            .Where(_ => _.Properties.Numbering != null)
+            .Select(_ => _.Properties.Numbering!.Text)
+            .ToList();
+    }
+
+    // One bullet list per level, each with its own numbering definition, and one paragraph in each.
+    static byte[] BuildDocx((string Font, string LevelText)[] levels)
+    {
+        var abstracts = new StringBuilder();
+        var nums = new StringBuilder();
+        var paragraphs = new StringBuilder();
+        for (var index = 0; index < levels.Length; index++)
+        {
+            var (font, levelText) = levels[index];
+            var id = index + 1;
+            abstracts.Append(
+                $"""
+                 <w:abstractNum w:abstractNumId="{id}">
+                   <w:lvl w:ilvl="0">
+                     <w:numFmt w:val="bullet"/>
+                     <w:lvlText w:val="{levelText}"/>
+                     <w:rPr><w:rFonts w:ascii="{font}" w:hAnsi="{font}"/></w:rPr>
+                   </w:lvl>
+                 </w:abstractNum>
+                 """);
+            nums.Append($"""<w:num w:numId="{id}"><w:abstractNumId w:val="{id}"/></w:num>""");
+            paragraphs.Append(
+                $"""
+                 <w:p>
+                   <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="{id}"/></w:numPr></w:pPr>
+                   <w:r><w:t>Option {id}</w:t></w:r>
+                 </w:p>
+                 """);
+        }
+
+        return BuildZip(
+            ("[Content_Types].xml",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                  <Default Extension="xml" ContentType="application/xml"/>
+                  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+                  <Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>
+                </Types>
+                """),
+            ("_rels/.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+                </Relationships>
+                """),
+            ("word/_rels/document.xml.rels",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+                </Relationships>
+                """),
+            ("word/numbering.xml",
+                $"""
+                 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                 <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                   {abstracts}{nums}
+                 </w:numbering>
+                 """),
+            ("word/document.xml",
+                $"""
+                 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                   <w:body>{paragraphs}</w:body>
+                 </w:document>
+                 """));
+    }
+
+    static byte[] BuildZip(params (string Name, string Content)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, content) in entries)
+            {
+                using var stream = zip.CreateEntry(name).Open();
+                using var writer = new StreamWriter(stream);
+                writer.Write(content);
+            }
+        }
+
+        return buffer.ToArray();
+    }
+}


### PR DESCRIPTION
A Word template that renders a questionnaire draws its checkboxes as list markers in Wingdings, and neither of the pair survived the hop onto the Unicode codepoints Bullets.ttf carries:

- 0xA8, the empty box, mapped to U+25A2 white square, which Bullets.ttf does not have - so the marker rendered as nothing at all.
- 0xFE, the checked box, was not in the switch and fell through to the small filled square every unrecognised Wingdings bullet defaults to.

Both now map onto the ballot boxes Bullets.ttf already carries for legacy FORMCHECKBOX fields.