### PR TITLE
Let a caller pin the paper a document does not state

### DIFF
--- a/src/Morph/Export/ExportOptions.cs
+++ b/src/Morph/Export/ExportOptions.cs
@@ -22,6 +22,18 @@ public abstract record ExportOptions
     public string? DefaultFont { get; init; }
 
     /// <summary>
+    /// The paper to fall back on when the source document states none — a worksheet with no
+    /// <c>pageSetup/@paperSize</c>, or a docx with no <c>w:pgSz</c>. <c>true</c> is US Letter,
+    /// <c>false</c> is A4.
+    ///
+    /// When <c>null</c> the machine's region decides, which is what Word and Excel do (Letter in
+    /// North America, A4 elsewhere) but makes the rendered page size depend on where the render
+    /// runs. Pin it for output that has to be reproducible across machines — snapshot tests most
+    /// of all, since a workbook stating no paper size is the common case rather than the rare one.
+    /// </summary>
+    public bool? UseLetterPageSize { get; init; }
+
+    /// <summary>
     /// Invoked for every feature the source document contained that couldn't be fully represented
     /// in the chosen output format — unsupported elements, missing fonts, inline images that
     /// failed to decode, etc. Null disables warning emission entirely.

--- a/src/Morph/OpenXml/DocumentConverter.cs
+++ b/src/Morph/OpenXml/DocumentConverter.cs
@@ -21,7 +21,7 @@ public abstract class DocumentConverter
     {
         options ??= new();
         DefaultFontSettings.MarkRenderOccurred();
-        var document = new DocumentParser(options.DefaultFont ?? DefaultFontSettings.DefaultFont).Parse(docxStream);
+        var document = new DocumentParser(options.DefaultFont ?? DefaultFontSettings.DefaultFont, options.UseLetterPageSize).Parse(docxStream);
         return PageSink.ToDirectory(
             outputDirectory,
             sink => RenderPages(document, options, sink));
@@ -40,7 +40,7 @@ public abstract class DocumentConverter
         options ??= new();
         DefaultFontSettings.MarkRenderOccurred();
 
-        var document = new DocumentParser(options.DefaultFont ?? DefaultFontSettings.DefaultFont).Parse(docxStream);
+        var document = new DocumentParser(options.DefaultFont ?? DefaultFontSettings.DefaultFont, options.UseLetterPageSize).Parse(docxStream);
         return PageSink.ToMemory(sink => RenderPages(document, options, sink));
     }
 
@@ -72,7 +72,7 @@ public abstract class DocumentConverter
         options ??= new();
         var pages = new Dictionary<string, int>(StringComparer.Ordinal);
 
-        var document = new DocumentParser(options.DefaultFont ?? DefaultFontSettings.DefaultFont).Parse(docxStream);
+        var document = new DocumentParser(options.DefaultFont ?? DefaultFontSettings.DefaultFont, options.UseLetterPageSize).Parse(docxStream);
         if (document.Bookmarks.Count == 0)
         {
             return pages;
@@ -190,7 +190,7 @@ public abstract class DocumentConverter
 
     /// <summary>Converts a DOCX stream to a semantic HTML fragment.</summary>
     public static string ConvertToHtml(Stream docxStream, HtmlExportOptions? options = null) =>
-        HtmlExporter.Export(Parse(docxStream, options?.DefaultFont), options);
+        HtmlExporter.Export(Parse(docxStream, options?.DefaultFont, options?.UseLetterPageSize), options);
 
     /// <summary>Converts a DOCX file to Markdown.</summary>
     public static string ConvertToMarkdown(string docxPath, MarkdownExportOptions? options = null)
@@ -201,10 +201,10 @@ public abstract class DocumentConverter
 
     /// <summary>Converts a DOCX stream to Markdown.</summary>
     public static string ConvertToMarkdown(Stream docxStream, MarkdownExportOptions? options = null) =>
-        MarkdownExporter.Export(Parse(docxStream, options?.DefaultFont), options);
+        MarkdownExporter.Export(Parse(docxStream, options?.DefaultFont, options?.UseLetterPageSize), options);
 
-    internal static ParsedDocument Parse(Stream docxStream, string? defaultFont) =>
-        new DocumentParser(defaultFont ?? DefaultFontSettings.DefaultFont).Parse(docxStream);
+    internal static ParsedDocument Parse(Stream docxStream, string? defaultFont, bool? useLetterPageSize = null) =>
+        new DocumentParser(defaultFont ?? DefaultFontSettings.DefaultFont, useLetterPageSize).Parse(docxStream);
 
     /// <summary>
     /// Renders a parsed document, invoking <paramref name="pageCallback"/> for each page (the

--- a/src/Morph/OpenXml/Parsing/DocumentParser.cs
+++ b/src/Morph/OpenXml/Parsing/DocumentParser.cs
@@ -18,7 +18,7 @@ using WPS = DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
 /// </summary>
 [SuppressMessage("Style", "IDE0028:Simplify collection initialization")]
 [SuppressMessage("Style", "IDE0306:Simplify collection initialization")]
-sealed class DocumentParser(string defaultFont)
+sealed class DocumentParser(string defaultFont, bool? useLetterPageSize = null)
 {
     // Conversion constants
 
@@ -3207,8 +3207,7 @@ sealed class DocumentParser(string defaultFont)
             }
         }
 
-        var width = DefaultPageSize.WidthPoints;
-        var height = DefaultPageSize.HeightPoints;
+        var (width, height) = DefaultPageSize.Resolve(useLetterPageSize);
         double marginTop = 72;
         var topMarginIsAbsolute = false;
         double marginBottom = 72;

--- a/src/Morph/Parsing/DefaultPageSize.cs
+++ b/src/Morph/Parsing/DefaultPageSize.cs
@@ -60,6 +60,15 @@ static class DefaultPageSize
     /// <summary>Default page height in points.</summary>
     public static double HeightPoints => UseLetterSize ? letterHeightPoints : a4HeightPoints;
 
+    /// <summary>
+    /// Dimensions for a caller that states which paper it wants, falling back to
+    /// <see cref="UseLetterSize"/> — and so to the machine's region — when it does not.
+    /// </summary>
+    public static (double Width, double Height) Resolve(bool? useLetter) =>
+        useLetter ?? UseLetterSize
+            ? (letterWidthPoints, letterHeightPoints)
+            : (a4WidthPoints, a4HeightPoints);
+
     static bool IsLetterRegion()
     {
         var region = RegionInfo.CurrentRegion;

--- a/src/Morph/Spreadsheet/ExcelConverter.cs
+++ b/src/Morph/Spreadsheet/ExcelConverter.cs
@@ -74,10 +74,10 @@ public abstract class ExcelConverter
     /// and through it the fit-to-page scale and the page count — depends on which face resolves.
     /// </summary>
     internal static ParsedDocument Parse(Stream xlsxStream, ExportOptions? options) =>
-        Parse(xlsxStream, options?.DefaultFont, options?.FontDirectory);
+        Parse(xlsxStream, options?.DefaultFont, options?.FontDirectory, options?.UseLetterPageSize);
 
-    internal static ParsedDocument Parse(Stream xlsxStream, string? defaultFont, string? fontDirectory) =>
-        new SpreadsheetParser(defaultFont ?? DefaultFontSettings.DefaultFont, fontDirectory)
+    internal static ParsedDocument Parse(Stream xlsxStream, string? defaultFont, string? fontDirectory, bool? useLetterPageSize = null) =>
+        new SpreadsheetParser(defaultFont ?? DefaultFontSettings.DefaultFont, fontDirectory, useLetterPageSize)
             .Parse(xlsxStream);
 
     /// <summary>

--- a/src/Morph/Spreadsheet/PaperSize.cs
+++ b/src/Morph/Spreadsheet/PaperSize.cs
@@ -11,8 +11,11 @@ static class PaperSize
     const double pointsPerInch = 72.0;
     const double pointsPerMillimetre = 72.0 / 25.4;
 
-    /// <summary>Portrait dimensions in points for a paper code, defaulting to the region's paper.</summary>
-    public static (double Width, double Height) Resolve(uint? code) =>
+    /// <summary>
+    /// Portrait dimensions in points for a paper code. A sheet naming none takes
+    /// <paramref name="useLetter"/>, and the region's paper when that is null too.
+    /// </summary>
+    public static (double Width, double Height) Resolve(uint? code, bool? useLetter = null) =>
         code switch
         {
             1 or 2 => (8.5 * pointsPerInch, 11 * pointsPerInch),      // Letter
@@ -23,6 +26,6 @@ static class PaperSize
             9 or 10 => (210 * pointsPerMillimetre, 297 * pointsPerMillimetre), // A4
             11 => (148 * pointsPerMillimetre, 210 * pointsPerMillimetre), // A5
             13 => (182 * pointsPerMillimetre, 257 * pointsPerMillimetre), // B5
-            _ => (DefaultPageSize.WidthPoints, DefaultPageSize.HeightPoints)
+            _ => DefaultPageSize.Resolve(useLetter)
         };
 }

--- a/src/Morph/Spreadsheet/SpreadsheetParser.cs
+++ b/src/Morph/Spreadsheet/SpreadsheetParser.cs
@@ -14,7 +14,7 @@
 /// are wide and do NOT ask to be fitted are scaled too, which is the one place this diverges from
 /// Excel — it under-sizes them instead of paginating sideways.
 /// </summary>
-sealed class SpreadsheetParser(string defaultFont, string? fontDirectory = null)
+sealed class SpreadsheetParser(string defaultFont, string? fontDirectory = null, bool? useLetterPageSize = null)
 {
     const double pointsPerInch = 72.0;
 
@@ -91,7 +91,7 @@ sealed class SpreadsheetParser(string defaultFont, string? fontDirectory = null)
             }
 
             var name = sheet.Name?.Value ?? string.Empty;
-            var settings = PageSettingsFor(worksheet);
+            var settings = PageSettingsFor(worksheet, useLetterPageSize);
 
             var range = ResolveRange(worksheet, definedNames.PrintArea(name));
             if (range is not { } bounds || bounds.IsEmpty)
@@ -354,12 +354,12 @@ sealed class SpreadsheetParser(string defaultFont, string? fontDirectory = null)
         return Math.Max(0, (columnWidth - tableWidth) / 2);
     }
 
-    static PageSettings PageSettingsFor(S.Worksheet worksheet)
+    static PageSettings PageSettingsFor(S.Worksheet worksheet, bool? useLetterPageSize)
     {
         var setup = worksheet.GetFirstChild<S.PageSetup>();
         var margins = worksheet.GetFirstChild<S.PageMargins>();
 
-        var (width, height) = PaperSize.Resolve(setup?.PaperSize?.Value);
+        var (width, height) = PaperSize.Resolve(setup?.PaperSize?.Value, useLetterPageSize);
         var landscape = setup?.Orientation?.Value == S.OrientationValues.Landscape;
 
         return new()

--- a/src/Tests/SpecTests/Spreadsheet/DefaultPaperSizeTests.cs
+++ b/src/Tests/SpecTests/Spreadsheet/DefaultPaperSizeTests.cs
@@ -1,0 +1,117 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+
+/// <summary>
+/// Covers <see cref="ExportOptions.UseLetterPageSize"/> against a worksheet that states no
+/// <c>pageSetup/@paperSize</c> — 72 of the 77 corpus sheets, so the common case rather than the
+/// rare one.
+///
+/// Such a sheet falls back to <c>DefaultPageSize</c>, which reads the machine's region: Letter in
+/// North America, A4 everywhere else, matching Excel. That is right for a person printing, and
+/// wrong for anything that has to reproduce — a snapshot baselined at A4 on one machine comes back
+/// 1275x1650 rather than 1240x1753 on a US-region CI agent, and the mismatch reads as a rendering
+/// regression rather than as a page-size difference.
+///
+/// A docx carries w:pgSz and a deck carries p:sldSz, so this is the one format where the fallback
+/// is routinely reached.
+/// </summary>
+public class DefaultPaperSizeTests
+{
+    const double a4WidthPoints = 595.28;
+    const double letterWidthPoints = 612;
+
+    [Test]
+    public async Task NoPaperSize_PinnedToA4_IgnoresRegion()
+    {
+        using var stream = SheetWithoutPageSetup();
+
+        var document = ExcelConverter.Parse(stream, new ImageExportOptions
+        {
+            UseLetterPageSize = false
+        });
+
+        await Assert.That(document.PageSettings.WidthPoints).IsEqualTo(a4WidthPoints).Within(0.01);
+    }
+
+    [Test]
+    public async Task NoPaperSize_PinnedToLetter_IgnoresRegion()
+    {
+        using var stream = SheetWithoutPageSetup();
+
+        var document = ExcelConverter.Parse(stream, new ImageExportOptions
+        {
+            UseLetterPageSize = true
+        });
+
+        await Assert.That(document.PageSettings.WidthPoints).IsEqualTo(letterWidthPoints).Within(0.01);
+    }
+
+    // The sheet's own paperSize still wins — the option is a fallback, not an override. 9 is A4.
+    [Test]
+    public async Task StatedPaperSize_WinsOverThePin()
+    {
+        using var stream = SheetWithoutPageSetup(paperSize: 9);
+
+        var document = ExcelConverter.Parse(stream, new ImageExportOptions
+        {
+            UseLetterPageSize = true
+        });
+
+        await Assert.That(document.PageSettings.WidthPoints).IsEqualTo(a4WidthPoints).Within(0.01);
+    }
+
+    // Unset keeps the pre-existing region behaviour, so no caller that never asked is moved. The
+    // harness pins DefaultPageSize.UseLetterSize = false, which is what "the region" resolves to
+    // under test.
+    [Test]
+    public async Task Unset_KeepsTheRegionDefault()
+    {
+        using var stream = SheetWithoutPageSetup();
+
+        var document = ExcelConverter.Parse(stream, new ImageExportOptions());
+
+        await Assert.That(document.PageSettings.WidthPoints).IsEqualTo(a4WidthPoints).Within(0.01);
+    }
+
+    static MemoryStream SheetWithoutPageSetup(uint? paperSize = null)
+    {
+        var worksheet = new S.Worksheet(
+            new S.SheetData(
+                new S.Row(
+                    new S.Cell
+                    {
+                        CellReference = "A1",
+                        DataType = S.CellValues.String,
+                        CellValue = new("x")
+                    })));
+
+        if (paperSize is { } code)
+        {
+            worksheet.AppendChild(
+                new S.PageSetup
+                {
+                    PaperSize = code
+                });
+        }
+
+        var stream = new MemoryStream();
+        using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+        {
+            var workbookPart = document.AddWorkbookPart();
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            worksheetPart.Worksheet = worksheet;
+            workbookPart.Workbook = new(
+                new S.Sheets(
+                    new S.Sheet
+                    {
+                        Id = workbookPart.GetIdOfPart(worksheetPart),
+                        SheetId = 1,
+                        Name = "Sheet1"
+                    }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+}


### PR DESCRIPTION
A worksheet with no pageSetup/@paperSize - 72 of the corpus's 77 - falls back to DefaultPageSize, which reads RegionInfo.CurrentRegion: Letter in North America, A4 elsewhere. That matches Excel, and is right for a person printing. It is wrong for anything that has to reproduce, because the page size then depends on where the render runs rather than on the document.

Verify.OpenXml hit this as soon as it started snapshotting rendered pages. Baselines generated on an A4-region machine at 1240x1753 came back from a US-region CI agent at 1275x1650, and the failure reads as a rendering regression rather than as a page-size difference. Only the spreadsheet path is exposed: a docx carries w:pgSz and a deck carries p:sldSz, so the fallback is routinely reached in exactly one format.

ExportOptions.UseLetterPageSize pins it. Threaded through the parsers rather than exposed as a settable static, so it stays per-render: DefaultPageSize and DefaultFontSettings are internal, and Morph's own harness can pin them only because it lives in the same assembly. It sits on ExportOptions beside FontDirectory, which is there for the same reason - the other half of making a render reproducible across machines.

Null keeps the region default, so no caller that never asked is moved, and the static override still applies underneath it. The sheet's own paperSize still wins: this is a fallback, not an override.

No baselines move. The DOCX path takes the same parameter for consistency, but every corpus document states its page size, so nothing there reaches it either.