### PR TITLE
Read a cell's own rich text, not just the shared table's

### DIFF
--- a/src/Morph/Spreadsheet/SharedStrings.cs
+++ b/src/Morph/Spreadsheet/SharedStrings.cs
@@ -22,12 +22,17 @@ sealed class SharedStrings
         index >= 0 && index < entries.Length ? entries[index] : string.Empty;
 
     /// <summary>
-    /// An entry is either one text node or a sequence of formatted runs. The runs' own formatting is
-    /// dropped: the model applies one style per cell, and a cell is the unit a spreadsheet formats.
+    /// The text of a rich string: either one text node or a sequence of formatted runs. The runs'
+    /// own formatting is dropped, because the model applies one style per cell and a cell is the
+    /// unit a spreadsheet formats.
+    ///
+    /// Typed as <see cref="OpenXmlElement"/> because the same content model — <c>CT_Rst</c> — backs
+    /// both a shared string entry and a cell's own <c>is</c>, and an inline rich string is otherwise
+    /// easy to read as its absent single <c>t</c> and so render blank.
     /// </summary>
-    static string Flatten(S.SharedStringItem item)
+    public static string Flatten(OpenXmlElement item)
     {
-        if (item.Text?.Text is { } single)
+        if (item.GetFirstChild<S.Text>()?.Text is { } single)
         {
             return single;
         }

--- a/src/Morph/Spreadsheet/SheetGridBuilder.cs
+++ b/src/Morph/Spreadsheet/SheetGridBuilder.cs
@@ -430,7 +430,8 @@ sealed class SheetGridBuilder(CellStyles styles, SharedStrings sharedStrings, st
 
         if (type == S.CellValues.InlineString)
         {
-            return (cell.GetFirstChild<S.InlineString>()?.Text?.Text ?? string.Empty, null);
+            var inline = cell.GetFirstChild<S.InlineString>();
+            return (inline == null ? string.Empty : SharedStrings.Flatten(inline), null);
         }
 
         if (type == S.CellValues.Boolean)

--- a/src/Tests/SpecTests/Spreadsheet/RichCellTextTests.cs
+++ b/src/Tests/SpecTests/Spreadsheet/RichCellTextTests.cs
@@ -1,0 +1,119 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using S = DocumentFormat.OpenXml.Spreadsheet;
+
+/// <summary>
+/// Rich text in a cell — <c>CT_Rst</c> carrying a sequence of formatted <c>r</c> runs instead of one
+/// <c>t</c> (ECMA-376 §18.4.8). A producer bolding part of a label writes this, and it is the shape
+/// an instruction banner above a header row usually takes.
+///
+/// The two places it appears share that content model but not the code that read it: the shared
+/// string table flattened runs, and a cell's own <c>is</c> did not, taking its absent single
+/// <c>t</c> and rendering blank. Both are covered here so they cannot drift apart again.
+/// </summary>
+public class RichCellTextTests
+{
+    [Test]
+    public async Task InlineRichRuns_AreRead()
+    {
+        using var stream = Workbook(RichInline());
+
+        var text = CellText(stream);
+
+        await Assert.That(text).IsEqualTo("Instructions: fill in every field.");
+    }
+
+    [Test]
+    public async Task SharedRichRuns_AreRead()
+    {
+        using var stream = SharedWorkbook();
+
+        var text = CellText(stream);
+
+        await Assert.That(text).IsEqualTo("Instructions: fill in every field.");
+    }
+
+    // The plain single-t form keeps working; the fallback must not shadow it.
+    [Test]
+    public async Task InlinePlainText_IsUnaffected()
+    {
+        using var stream = Workbook(
+            new S.Cell
+            {
+                CellReference = "A1",
+                DataType = S.CellValues.InlineString,
+                InlineString = new(new S.Text("plain"))
+            });
+
+        var text = CellText(stream);
+
+        await Assert.That(text).IsEqualTo("plain");
+    }
+
+    static string CellText(Stream stream)
+    {
+        var document = ExcelConverter.Parse(stream, new ImageExportOptions());
+        var table = document.Elements.OfType<TableElement>().Single();
+        return string.Concat(
+            table.Rows[0].Cells[0].Content
+                .OfType<ParagraphElement>()
+                .SelectMany(_ => _.Runs)
+                .Select(_ => _.Text));
+    }
+
+    static S.Cell RichInline() =>
+        new()
+        {
+            CellReference = "A1",
+            DataType = S.CellValues.InlineString,
+            InlineString = new(
+                new S.Run(
+                    new S.RunProperties(new S.Bold()),
+                    new S.Text("Instructions: ")),
+                new S.Run(
+                    new S.Text("fill in every field.")))
+        };
+
+    static MemoryStream Workbook(S.Cell cell, Action<WorkbookPart>? configure = null)
+    {
+        var stream = new MemoryStream();
+        using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+        {
+            var workbookPart = document.AddWorkbookPart();
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            worksheetPart.Worksheet = new(new S.SheetData(new S.Row(cell)));
+            configure?.Invoke(workbookPart);
+            workbookPart.Workbook = new(
+                new S.Sheets(
+                    new S.Sheet
+                    {
+                        Id = workbookPart.GetIdOfPart(worksheetPart),
+                        SheetId = 1,
+                        Name = "Sheet1"
+                    }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    static MemoryStream SharedWorkbook() =>
+        Workbook(
+            new S.Cell
+            {
+                CellReference = "A1",
+                DataType = S.CellValues.SharedString,
+                CellValue = new("0")
+            },
+            workbookPart =>
+            {
+                var part = workbookPart.AddNewPart<SharedStringTablePart>();
+                part.SharedStringTable = new(
+                    new S.SharedStringItem(
+                        new S.Run(
+                            new S.RunProperties(new S.Bold()),
+                            new S.Text("Instructions: ")),
+                        new S.Run(
+                            new S.Text("fill in every field."))));
+            });
+}


### PR DESCRIPTION
CT_Rst holds either a single t or a sequence of formatted r runs (18.4.8), and both a shared string entry and a cell's own is use that content model. Only the shared table read it that way. A cell carrying inline rich text was read through its absent single t and came out empty, so the cell rendered blank.

The two readers had drifted rather than one being wrong from the start - the shared path carries a comment about dropping run formatting, so the run case was considered there and simply never mirrored. They now share the one flatten, typed on OpenXmlElement since that is the only thing the two element types have in common.

Found in Verify.OpenXml, where a fixture's instruction banner - a merged A1:C1 cell whose text bolds "Instructions:" and leaves the rest plain - was missing from a page that drew every other row. That was the last thing still absent from those pages after the implied-position fix, and the two are unrelated: this one would have blanked the cell whether or not its position was stated.

No corpus baseline moves. The corpus stores its rich text in the shared table, which already worked, so this only reaches producers that inline it.